### PR TITLE
Support passing a UIImageView as the displacedView

### DIFF
--- a/ImageViewer/Source/ImageViewer/GalleryPresentTransition.swift
+++ b/ImageViewer/Source/ImageViewer/GalleryPresentTransition.swift
@@ -69,6 +69,11 @@ final class GalleryPresentTransition: NSObject, UIViewControllerAnimatedTransiti
         animatedImageView.bounds = displacedView.bounds
         animatedImageView.frame.origin = origin
         animatedImageView.image = screenshot
+
+        // Special case for where displaced view is an UIImageView
+        if let displacedImageView = displacedView as? UIImageView {
+            animatedImageView.contentMode = displacedImageView.contentMode
+        }
         
         /// Put it into the container
         transitionContainerView.addSubview(animatedImageView)

--- a/ImageViewer/Source/UtilityFunctions.swift
+++ b/ImageViewer/Source/UtilityFunctions.swift
@@ -50,6 +50,11 @@ func zoomRect(ForScrollView scrollView: UIScrollView, scale: CGFloat, center: CG
 
 func screenshotFromView(view: UIView) -> UIImage {
     
+    // Special case for where displaced view is an UIImageView
+    if let imageView = view as? UIImageView, image = imageView.image {
+        return image
+    }
+
     let image: UIImage
     
     UIGraphicsBeginImageContextWithOptions(view.bounds.size, true, UIScreen.mainScreen().scale)


### PR DESCRIPTION
Passing a UIImageView as the displacement view may add borders to the `animatedImageView` found in the `GalleryPresentTransition`. This results in a broken animation.

This solution reuses the existing UIImage from the passed in UIImageView and matches the contentMode of the `animatedImageView` with the passed in `displacedImageView`.

