### PR TITLE
Gallery overlay view does not cover whole screen when presented in a modal view controller

### DIFF
--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -152,12 +152,9 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     
     fileprivate func configureOverlayView() {
 
-        /// Make the overlay view occupy the whole screen
         overlayView.bounds.size = UIScreen.main.bounds.insetBy(dx: -UIScreen.main.bounds.width / 2, dy: -UIScreen.main.bounds.height / 2).size
         overlayView.center = CGPoint(x: (UIScreen.main.bounds.width / 2), y: (UIScreen.main.bounds.height / 2))
         
-        /// Add the overlay to the back of the gallery view controller instead of the original one
-        /// This fixes the problem of not opening the gallery in fullScreen when it's originated on a Modal controller
         self.view.addSubview(overlayView)
         self.view.sendSubview(toBack: overlayView)
     }

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -149,7 +149,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
 
         NotificationCenter.default.removeObserver(self)
     }
-    
+
     fileprivate func configureOverlayView() {
 
         overlayView.bounds.size = UIScreen.main.bounds.insetBy(dx: -UIScreen.main.bounds.width / 2, dy: -UIScreen.main.bounds.height / 2).size

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -149,16 +149,17 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
 
         NotificationCenter.default.removeObserver(self)
     }
-
+    
     fileprivate func configureOverlayView() {
 
+        /// Make the overlay view occupy the whole screen
         overlayView.bounds.size = UIScreen.main.bounds.insetBy(dx: -UIScreen.main.bounds.width / 2, dy: -UIScreen.main.bounds.height / 2).size
-
-        if let controller = self.presentingViewController {
-
-            overlayView.center = controller.view.boundsCenter
-            controller.view.addSubview(overlayView)
-        }
+        overlayView.center = CGPoint(x: (UIScreen.main.bounds.width / 2), y: (UIScreen.main.bounds.height / 2))
+        
+        /// Add the overlay to the back of the gallery view controller instead of the original one
+        /// This fixes the problem of not opening the gallery in fullScreen when it's originated on a Modal controller
+        self.view.addSubview(overlayView)
+        self.view.sendSubview(toBack: overlayView)
     }
 
     fileprivate func configureHeaderView() {


### PR DESCRIPTION
Overlay view added to the back of the gallery instead of the original view controller.