### PR TITLE
When gallery is rotated, the overlay view does not fill the whole screen

### DIFF
--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -210,7 +210,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
         configureThumbnailsButton()
         configureScrubber()
         
-        view.clipsToBounds = false
+        self.view.clipsToBounds = false
     }
 
     open override func viewDidAppear(_ animated: Bool) {

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -209,6 +209,8 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
         configureCloseButton()
         configureThumbnailsButton()
         configureScrubber()
+        
+        view.clipsToBounds = false
     }
 
     open override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
Because of my last PR, the overlay view is now being added to the Gallery's view.

The gallery is clipping the subviews to its bounds, so it causes the overlay view to not fill the whole area of the screen when rotating.

Just by not clipping the subviews, the overlay view is now occupying the whole screen during the rotation animation. Sorry for not testing this previously! :)