### PR TITLE
Avoid float comparison in aspectFillZoomScale

### DIFF
--- a/ImageViewer/Source/UtilityFunctions.swift
+++ b/ImageViewer/Source/UtilityFunctions.swift
@@ -26,7 +26,7 @@ func aspectFitContentSize(forBoundingSize boundingSize: CGSize, contentSize: CGS
 func aspectFillZoomScale(forBoundingSize boundingSize: CGSize, contentSize: CGSize) -> CGFloat {
     
     let aspectFitSize = aspectFitContentSize(forBoundingSize: boundingSize, contentSize: contentSize)
-    return (boundingSize.width == aspectFitSize.width) ? (boundingSize.height / aspectFitSize.height): (boundingSize.width / aspectFitSize.width)
+    return (floor(boundingSize.width) == floor(aspectFitSize.width)) ? (boundingSize.height / aspectFitSize.height): (boundingSize.width / aspectFitSize.width)
 }
 
 func contentCenter(forBoundingSize boundingSize: CGSize, contentSize: CGSize) -> CGPoint {


### PR DESCRIPTION
In some cases with some devices (i.e: iPhone 7plus simulator and image 7/7 of the example), the return from `AVMakeRectWithAspectRatioInsideRect` in `aspectFitContentSize:` has some decimals that makes this comparison to be false, provoking a bug when zooming in.

This PR comes from the issue: https://github.com/MailOnline/ImageViewer/issues/96