### PR TITLE
ThumbnailsViewController loading improvements

### DIFF
--- a/ImageViewer/Source/GalleryConfiguration.swift
+++ b/ImageViewer/Source/GalleryConfiguration.swift
@@ -39,14 +39,23 @@ public enum GalleryConfigurationItem {
     /// Layout behaviour for the Thumbnails button.
     case thumbnailsLayout(ButtonLayout)
 
+    /// Option to show a spinner over the thumbnail image that is loading
+    case thumbnailsActivityIndicator(Bool)
+    
     /// Layout behaviour for the Delete button.
     case deleteLayout(ButtonLayout)
 
     /// This spinner is shown when we page to an image page, but the image itself is still loading.
     case spinnerStyle(UIActivityIndicatorViewStyle)
-
+    
     /// Tint color for the spinner.
     case spinnerColor(UIColor)
+    
+    /// This spinner is shown when we are loading thumbnails
+    case thumbnailsSpinnerStyle(UIActivityIndicatorViewStyle)
+    
+    /// Tint color for the thumbnails spinner.
+    case thumbnailsSpinnerColor(UIColor)
 
     /// Layout behaviour for optional header view.
     case headerViewLayout(HeaderLayout)
@@ -146,6 +155,9 @@ public enum GalleryConfigurationItem {
 
     ///Allows to set rotation support support with relation to rotation support in the hosting app.
     case rotationMode(GalleryRotationMode)
+    
+    ///Allows to set a placeholder image which will be visible during the load of GalleryItem
+    case placeHolderImage(UIImage?)
 }
 
 public enum GalleryRotationMode {

--- a/ImageViewer/Source/ItemBaseController.swift
+++ b/ImageViewer/Source/ItemBaseController.swift
@@ -56,7 +56,9 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
 
     // TRANSITIONS
     fileprivate var swipeToDismissTransition: GallerySwipeToDismissTransition?
-
+    
+    // Placeholder
+    public var placeHolderImage : UIImage? = nil;
 
     // MARK: - Initializers
 
@@ -86,7 +88,8 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
             case .toggleDecorationViewsBySingleTap(let enabled):    toggleDecorationViewBySingleTap = enabled
             case .spinnerColor(let color):                          activityIndicatorView.color = color
             case .spinnerStyle(let style):                          activityIndicatorView.activityIndicatorViewStyle = style
-
+            case .placeHolderImage(let phImage):                    placeHolderImage = phImage
+            
             case .displacementTransitionStyle(let style):
 
                 switch style {
@@ -182,7 +185,11 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
     }
 
     public func fetchImage() {
-
+        
+        if let ph : UIImage = self.placeHolderImage {
+            self.itemView.image = ph
+        }
+        
         fetchImageBlock { [weak self] image in
 
             if let image = image {
@@ -547,10 +554,11 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
 
                 self?.itemView.alpha = 0
 
-            }, completion: { [weak self] _ in
+                }, completion: { [weak self] _ in
 
-                self?.isAnimating = false
-                completion()
+                    self?.isAnimating = false
+                    completion()
+                    self?.itemView.alpha = 1
             })
         }
     }

--- a/ImageViewer/Source/Thumbnails Controller/ThumbnailsViewController.swift
+++ b/ImageViewer/Source/Thumbnails Controller/ThumbnailsViewController.swift
@@ -20,6 +20,14 @@ class ThumbnailsViewController: UICollectionViewController, UICollectionViewDele
     weak var itemsDataSource: GalleryItemsDataSource!
     var closeButton: UIButton?
     var closeLayout: ButtonLayout?
+    
+    /// An optional Image which will be visible during the load of GalleryItem FetchImageBlock
+    var placeHolderImage : UIImage? = nil
+    
+    //An optional indicator which will be visible during the load of GalleryItem FetchImageBlock
+    var useActivityIndicator = false
+    var thumbnailsactivityIndicatorViewStyle : UIActivityIndicatorViewStyle = .white
+    var thumbnailsactivityIndicatorViewColor : UIColor = UIColor.white
 
     required init(itemsDataSource: GalleryItemsDataSource) {
         self.itemsDataSource = itemsDataSource
@@ -37,6 +45,15 @@ class ThumbnailsViewController: UICollectionViewController, UICollectionViewDele
         NotificationCenter.default.removeObserver(self)
     }
 
+    
+    /// Called when re-initializing to make sure we have the latest data.
+    /// Allows us to cache our instance
+    /// - Parameter itemsDataSource: data source
+    public func updateDataSource(itemsDataSource: GalleryItemsDataSource) {
+        self.itemsDataSource = itemsDataSource
+        self.collectionView?.reloadData()
+    }
+    
     func rotate() {
         guard UIApplication.isPortraitOnly else { return }
 
@@ -103,7 +120,21 @@ class ThumbnailsViewController: UICollectionViewController, UICollectionViewDele
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as! ThumbnailCell
 
         let item = itemsDataSource.provideGalleryItem((indexPath as NSIndexPath).row)
-
+        
+        var activityIndicatorView : UIActivityIndicatorView? = nil
+        
+        if let ph : UIImage = self.placeHolderImage {
+            cell.imageView.image = ph
+        } else if (useActivityIndicator) {
+            activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle: thumbnailsactivityIndicatorViewStyle)
+            activityIndicatorView!.color = thumbnailsactivityIndicatorViewColor
+            activityIndicatorView!.hidesWhenStopped = true
+            activityIndicatorView!.center = cell.contentView.boundsCenter
+            cell.imageView.addSubview(activityIndicatorView!)
+            activityIndicatorView!.startAnimating()
+        }
+        
+        
         switch item {
 
         case .image(let fetchImageBlock):
@@ -111,8 +142,8 @@ class ThumbnailsViewController: UICollectionViewController, UICollectionViewDele
             fetchImageBlock() { image in
 
                 if let image = image {
-
                     cell.imageView.image = image
+                    activityIndicatorView?.stopAnimating()
                 }
             }
 
@@ -123,6 +154,7 @@ class ThumbnailsViewController: UICollectionViewController, UICollectionViewDele
                 if let image = image {
 
                     cell.imageView.image = image
+                    activityIndicatorView?.stopAnimating()
                 }
             }
 
@@ -133,6 +165,7 @@ class ThumbnailsViewController: UICollectionViewController, UICollectionViewDele
                 if let image = image {
 
                     cell.imageView.image = image
+                    activityIndicatorView?.stopAnimating()
                 }
             }
         }


### PR DESCRIPTION
1. Added an option to show an activity indicator on top of thumbnail cells as images load.
2. Added an option to pass in a UIImage to be used as a placeholder image while loading the primary image. (IE: custom loader)
3. Added caching to gallery view controller so it does not have to reload everything if you close and open it again
4. Made some minor changes to allow for GalleryViewController to be cached in the consumer VC allowing a user to only initialize it once but present it multiple times. Part of this included moving the statusBar setting to viewDidAppear