### PR TITLE
Allow color of video controls to be set

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -113,6 +113,8 @@ class ViewController: UIViewController {
             GalleryConfigurationItem.overlayColorOpacity(1),
             GalleryConfigurationItem.overlayBlurOpacity(1),
             GalleryConfigurationItem.overlayBlurStyle(UIBlurEffectStyle.light),
+            
+            GalleryConfigurationItem.videoControlsColor(.white),
 
             GalleryConfigurationItem.maximumZoomScale(8),
             GalleryConfigurationItem.swipeToDismissThresholdVelocity(500),

--- a/ImageViewer.xcodeproj/project.pbxproj
+++ b/ImageViewer.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13BDF0711E573C78009C458F /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BDF0701E573C78009C458F /* UIColor.swift */; };
+		13BDF0721E573D10009C458F /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BDF0701E573C78009C458F /* UIColor.swift */; };
 		4CD1C49C1C16FF64008D5F84 /* CGPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD1C49B1C16FF64008D5F84 /* CGPoint.swift */; };
 		4CD1C49D1C16FF64008D5F84 /* CGPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD1C49B1C16FF64008D5F84 /* CGPoint.swift */; };
 		5AF0E6605E3B055280A902DF /* GalleryItemsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0EF3CAFE8B7972354F05D /* GalleryItemsDelegate.swift */; };
@@ -90,6 +92,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		13BDF0701E573C78009C458F /* UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		4CD1C49B1C16FF64008D5F84 /* CGPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGPoint.swift; sourceTree = "<group>"; };
 		5AF0EF3CAFE8B7972354F05D /* GalleryItemsDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GalleryItemsDelegate.swift; sourceTree = "<group>"; };
 		A32D40031D45C4DE00AB5ADA /* Bool.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bool.swift; sourceTree = "<group>"; };
@@ -263,6 +266,7 @@
 				EB3464EE1D4B8E88009494B5 /* CALayer.swift */,
 				EB17B3771D4A51D200EED1DA /* UIBezierPath.swift */,
 				EB3464F41D4BAA19009494B5 /* UISlider.swift */,
+				13BDF0701E573C78009C458F /* UIColor.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -535,6 +539,7 @@
 				EB6F46561D46640D00984035 /* VideoView.swift in Sources */,
 				EB8BEC7A1D3D1CB500DCE3EC /* ItemControllerDelegate.swift in Sources */,
 				EBA90E431C875225000AA697 /* ImageFadeInHandler.swift in Sources */,
+				13BDF0721E573D10009C458F /* UIColor.swift in Sources */,
 				4CD1C49C1C16FF64008D5F84 /* CGPoint.swift in Sources */,
 				EBA76F711D4F855C0094931F /* ItemBaseController.swift in Sources */,
 				EB4DEBC01C84A6FD00D5F897 /* UIView.swift in Sources */,
@@ -574,6 +579,7 @@
 				EB1CEC1F1C84A54600BB27B8 /* UtilityFunctions.swift in Sources */,
 				A32D40041D45C4DE00AB5ADA /* Bool.swift in Sources */,
 				C7DABE641C12276800F5BD7B /* CGSize.swift in Sources */,
+				13BDF0711E573C78009C458F /* UIColor.swift in Sources */,
 				EBA0A9541C89C653005B8DD3 /* GalleryConfiguration.swift in Sources */,
 				EB17B3791D4A51D200EED1DA /* UIBezierPath.swift in Sources */,
 				EB1DB6EA1D3E595D00DC9064 /* UIApplication.swift in Sources */,

--- a/ImageViewer/Source/Extensions/UIColor.swift
+++ b/ImageViewer/Source/Extensions/UIColor.swift
@@ -1,0 +1,25 @@
+//
+//  UIColor.swift
+//  ImageViewer
+//
+//  Created by Ross Butler on 17/02/2017.
+//  Copyright © 2017 MailOnline. All rights reserved.
+//
+
+import UIKit
+
+extension UIColor {
+    
+    open func shadeDarker() -> UIColor {
+        var r: CGFloat = 0.0, g: CGFloat = 0.0, b: CGFloat = 0.0, a: CGFloat = 0.0
+        self.getRed(&r, green: &g, blue: &b, alpha: &a)
+        
+        let variance: CGFloat = 0.4
+        let newR = CGFloat.maximum(r * variance, 0.0),
+        newG = CGFloat.maximum(g * variance, 0.0),
+        newB = CGFloat.maximum(b * variance, 0.0)
+        
+        return UIColor(red: newR, green: newG, blue: newB, alpha: 1.0)
+    }
+    
+}

--- a/ImageViewer/Source/Extensions/UISlider.swift
+++ b/ImageViewer/Source/Extensions/UISlider.swift
@@ -31,4 +31,13 @@ extension Slider {
 
         return slider
     }
+    
+    override func tintColorDidChange() {
+        self.minimumTrackTintColor = self.tintColor
+        self.maximumTrackTintColor = self.tintColor.shadeDarker()
+        
+        // Correct way would be setting self.thumbTintColor however this has a bug which changes the thumbImage frame
+        let image = self.currentThumbImage?.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
+        self.setThumbImage(image, for: UIControlState.normal)
+    }
 }

--- a/ImageViewer/Source/GalleryConfiguration.swift
+++ b/ImageViewer/Source/GalleryConfiguration.swift
@@ -149,6 +149,9 @@ public enum GalleryConfigurationItem {
     
     ///Allows auto play video after gallery presented
     case videoAutoPlay(Bool)
+
+    /// Tint color of video controls
+    case videoControlsColor(UIColor)
 }
 
 public enum GalleryRotationMode {

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -102,7 +102,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
             case .blurDismissDelay(let delay):                  overlayView.blurDismissDelay = delay
             case .colorDismissDuration(let duration):           overlayView.colorDismissDuration = duration
             case .colorDismissDelay(let delay):                 overlayView.colorDismissDelay = delay
-
+            case .videoControlsColor(let color):                scrubber.tintColor = color
             case .closeButtonMode(let buttonMode):
 
                 switch buttonMode {

--- a/ImageViewer/Source/VideoScrubber.swift
+++ b/ImageViewer/Source/VideoScrubber.swift
@@ -97,6 +97,7 @@ open class VideoScrubber: UIControl {
 
     func setup() {
 
+        self.tintColor = .white
         self.clipsToBounds = true
         pauseButton.isHidden = true
         replayButton.isHidden = true
@@ -105,7 +106,7 @@ open class VideoScrubber: UIControl {
         scrubber.maximumValue = 1000
         scrubber.value = 0
 
-        timeLabel.attributedText = NSAttributedString(string: "--:--", attributes: [NSForegroundColorAttributeName : UIColor.white, NSFontAttributeName : UIFont.systemFont(ofSize: 12)])
+        timeLabel.attributedText = NSAttributedString(string: "--:--", attributes: [NSForegroundColorAttributeName : self.tintColor, NSFontAttributeName : UIFont.systemFont(ofSize: 12)])
         timeLabel.textAlignment =  .center
 
         playButton.addTarget(self, action: #selector(play), for: UIControlEvents.touchUpInside)
@@ -237,10 +238,10 @@ open class VideoScrubber: UIControl {
 
             let timeString = stringFromTimeInterval(currentTime as TimeInterval)
 
-            timeLabel.attributedText = NSAttributedString(string: timeString, attributes: [NSForegroundColorAttributeName : UIColor.white, NSFontAttributeName : UIFont.systemFont(ofSize: 12)])
+            timeLabel.attributedText = NSAttributedString(string: timeString, attributes: [NSForegroundColorAttributeName : self.tintColor, NSFontAttributeName : UIFont.systemFont(ofSize: 12)])
         }
         else {
-            timeLabel.attributedText = NSAttributedString(string: "--:--", attributes: [NSForegroundColorAttributeName : UIColor.white, NSFontAttributeName : UIFont.systemFont(ofSize: 12)])
+            timeLabel.attributedText = NSAttributedString(string: "--:--", attributes: [NSForegroundColorAttributeName : self.tintColor, NSFontAttributeName : UIFont.systemFont(ofSize: 12)])
         }
     }
 
@@ -254,5 +255,48 @@ open class VideoScrubber: UIControl {
 
         return NSString(format: "%0.2d:%0.2d",minutes,seconds) as String
         //return NSString(format: "%0.2d:%0.2d:%0.2d",hours,minutes,seconds) as String
+    }
+    
+    override open func tintColorDidChange() {
+        timeLabel.attributedText = NSAttributedString(string: "--:--", attributes: [NSForegroundColorAttributeName : self.tintColor, NSFontAttributeName : UIFont.systemFont(ofSize: 12)])
+        
+        let playButtonImage = playButton.imageView?.image?.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
+        playButton.imageView?.tintColor = self.tintColor
+        playButton.setImage(playButtonImage, for: .normal)
+        
+        if let playButtonImage = playButtonImage,
+            let highlightImage = self.image(playButtonImage, with: self.tintColor.shadeDarker()) as UIImage? {
+            playButton.setImage(highlightImage, for: .highlighted)
+        }
+        
+        let pauseButtonImage = pauseButton.imageView?.image?.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
+        pauseButton.imageView?.tintColor = self.tintColor
+        pauseButton.setImage(pauseButtonImage, for: .normal)
+        
+        if let pauseButtonImage = pauseButtonImage,
+            let highlightImage = self.image(pauseButtonImage, with: self.tintColor.shadeDarker()) as UIImage? {
+            pauseButton.setImage(highlightImage, for: .highlighted)
+        }
+        
+        let replayButtonImage = replayButton.imageView?.image?.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
+        replayButton.imageView?.tintColor = self.tintColor
+        replayButton.setImage(replayButtonImage, for: .normal)
+        
+        if let replayButtonImage = replayButtonImage,
+            let highlightImage = self.image(replayButtonImage, with: self.tintColor.shadeDarker()) as UIImage? {
+            replayButton.setImage(highlightImage, for: .highlighted)
+        }
+    }
+    
+    func image(_ image: UIImage, with color: UIColor) -> UIImage? {
+        UIGraphicsBeginImageContext(image.size)
+        let rect = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+        let context = UIGraphicsGetCurrentContext()
+        context?.setFillColor(color.cgColor)
+        context?.clip(to: rect, mask: image.cgImage!)
+        context?.fill(CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+        let fillImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return fillImage
     }
 }


### PR DESCRIPTION
Added a new GalleryConfigurationItem named .videoControlsColor which allows the color of the scrubber, buttons and elapsed time label to be colored based on the UIColor option supplied.