### PR TITLE
Disable delete button when animation is in progress

### DIFF
--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -397,8 +397,14 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
 
     @objc fileprivate func deleteItem() {
 
+        deleteButton?.isEnabled = false
+
         itemsDelegate?.removeGalleryItem(at: currentIndex)
         removePage(atIndex: currentIndex)
+        {
+            [weak self] in
+            self?.deleteButton?.isEnabled = true
+        }
     }
 
     //ThumbnailsimageBlock
@@ -451,7 +457,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
         }
     }
 
-    func removePage(atIndex index: Int) {
+    func removePage(atIndex index: Int, completion: @escaping () -> Void) {
 
         // If removing last item, go back, otherwise, go forward
 
@@ -462,7 +468,11 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
         if newIndex < 0 { close(); return }
 
         let vc = self.pagingDataSource.createItemController(newIndex)
-        setViewControllers([vc], direction: direction, animated: true, completion: nil)
+        setViewControllers([vc], direction: direction, animated: true)
+        {
+            _ in
+            completion()
+        }
     }
 
     open func reload(atIndex index: Int) {

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -401,8 +401,8 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
         view.isUserInteractionEnabled = false
 
         itemsDelegate?.removeGalleryItem(at: currentIndex)
-        removePage(atIndex: currentIndex)
-        {
+        removePage(atIndex: currentIndex) {
+
             [weak self] in
             self?.deleteButton?.isEnabled = true
             self?.view.isUserInteractionEnabled = true
@@ -470,11 +470,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
         if newIndex < 0 { close(); return }
 
         let vc = self.pagingDataSource.createItemController(newIndex)
-        setViewControllers([vc], direction: direction, animated: true)
-        {
-            _ in
-            completion()
-        }
+        setViewControllers([vc], direction: direction, animated: true) { _ in completion() }
     }
 
     open func reload(atIndex index: Int) {

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -398,12 +398,14 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     @objc fileprivate func deleteItem() {
 
         deleteButton?.isEnabled = false
+        view.isUserInteractionEnabled = false
 
         itemsDelegate?.removeGalleryItem(at: currentIndex)
         removePage(atIndex: currentIndex)
         {
             [weak self] in
             self?.deleteButton?.isEnabled = true
+            self?.view.isUserInteractionEnabled = true
         }
     }
 

--- a/ImageViewer/Source/ItemBaseController.swift
+++ b/ImageViewer/Source/ItemBaseController.swift
@@ -159,6 +159,7 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
             swipeToDismissRecognizer.addTarget(self, action: #selector(scrollViewDidSwipeToDismiss))
             swipeToDismissRecognizer.delegate = self
             view.addGestureRecognizer(swipeToDismissRecognizer)
+            swipeToDismissRecognizer.require(toFail: doubleTapRecognizer)
         }
     }
 


### PR DESCRIPTION
Without these changes, a fast repetitive tap on the delete button will lead to a `fatal error: Index out of range`. The delete button needs to be disabled until the dismiss animation of the image is complete.