### PR TITLE
Forward accessibility fields from image to item

### DIFF
--- a/ImageViewer/Source/ItemBaseController.swift
+++ b/ImageViewer/Source/ItemBaseController.swift
@@ -190,7 +190,11 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
                 DispatchQueue.main.async {
                     self?.activityIndicatorView.stopAnimating()
 
-                    self?.itemView.image = image
+                    var itemView = self?.itemView
+                    itemView?.image = image
+                    itemView?.isAccessibilityElement = image.isAccessibilityElement
+                    itemView?.accessibilityLabel = image.accessibilityLabel
+                    itemView?.accessibilityTraits = image.accessibilityTraits
 
                     self?.view.setNeedsLayout()
                     self?.view.layoutIfNeeded()


### PR DESCRIPTION
In order to gallery be more accessible, we would set the accessibility fields. That way VoiceOver users will have some image context.